### PR TITLE
Prevent __closed name mangling causing AttributeErrors

### DIFF
--- a/aioring/aio.pyx
+++ b/aioring/aio.pyx
@@ -152,10 +152,10 @@ cdef long POS_NONE = 0xffffffffffffffff
 
 
 cdef class AsyncIOBase:
-    cdef bint __closed
+    cdef bint _closed
 
     def __init__(self):
-        self.__closed = False
+        self._closed = False
 
     cdef int _unsupported(self, str name) except -1:
         """Internal: raise an OSError exception for unsupported operations."""
@@ -182,11 +182,11 @@ cdef class AsyncIOBase:
 
         This method has no effect if the file is already closed.
         """
-        if not self.__closed:
+        if not self._closed:
             try:
                 await self.flush()
             finally:
-                self.__closed = True
+                self._closed = True
 
     def __del__(self):
         """Destructor.  Calls close()."""
@@ -210,7 +210,7 @@ cdef class AsyncIOBase:
             # the end users, we suppress the traceback.
             try:
                 os.close(self.fileno())
-                self.__closed = True
+                self._closed = True
             except:
                 pass
 
@@ -244,10 +244,10 @@ cdef class AsyncIOBase:
 
     @property
     def closed(self):
-        return self.__closed
+        return self._closed
 
     cdef int _checkClosed(self, str msg=None) except -1:
-        if self.__closed:
+        if self._closed:
             raise ValueError("I/O operation on closed file."
                              if msg is None else msg)
 
@@ -432,12 +432,12 @@ cdef class _AsyncBufferedIOMixin(AsyncBufferedIOBase):
         return await self.raw.truncate(pos)
 
     async def flush(self):
-        if self.__closed:
+        if self._closed:
             raise ValueError("flush on closed file")
         await self.raw.flush()
 
     async def close(self):
-        if self.raw is not None and not self.__closed:
+        if self.raw is not None and not self._closed:
             try:
                 await self.flush()
             finally:
@@ -1127,7 +1127,7 @@ cdef class AsyncFileIO(AsyncRawIOBase):
                     await aos.close(self._fd)
             finally:
                 await super().close()
-                self.__closed = True
+                self._closed = True
 
     cpdef bint seekable(self):
         return True


### PR DESCRIPTION
`AsyncIOBase` defined `__closed`, but this field was read by `_AsyncBufferedIOMixin` and mutated by `AsyncFileIO`. Since leading double-underscores mangles the attribute names (resulting in the actual qualified name of `AsyncIOBase.__AsyncIOBase_closed`), the usages by `_AsyncBufferedIOMixin` and `AsyncFileIO` resulted in `AttributeError`s.

Since `cdef` attrs are inaccessible through Python by default (unless declared with `public` or `readonly`), the mangling is redundant. Thus, `__closed` has simply been changed to `_closed`, enabling reads/writes from subclasses.

Here are some of the exceptions encountered when running the tests from a fresh repo:
```
======================================================================
ERROR: test_open_read_binary (tests.aio.test_aio.AioTest.test_open_read_binary)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/they4kman/programming/third-party/aioring/tests/aio/base.py", line 13, in _callTestMethod
    loop.run_until_complete(method())
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/futures.py", line 203, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/lib/python3.12/asyncio/tasks.py", line 314, in __step_run_and_handle_result
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/home/they4kman/programming/third-party/aioring/tests/aio/test_aio.py", line 18, in test_open_read_binary
    async with await aio.open("tests/data/test.txt", "rb") as file:
  File "aioring/aio.pyx", line 263, in __aexit__
    await self.close()
  File "aioring/aio.pyx", line 440, in close
    if self.raw is not None and not self.__closed:
AttributeError: 'aioring.aio.AsyncBufferedReader' object has no attribute '_AsyncBufferedIOMixin__closed'

======================================================================
ERROR: test_open_write_binary (tests.aio.test_aio.AioTest.test_open_write_binary)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/they4kman/programming/third-party/aioring/tests/aio/base.py", line 13, in _callTestMethod
    loop.run_until_complete(method())
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/futures.py", line 203, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/lib/python3.12/asyncio/tasks.py", line 314, in __step_run_and_handle_result
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/home/they4kman/programming/third-party/aioring/tests/aio/test_aio.py", line 32, in test_open_write_binary
    async with await aio.open("tests/data/new.txt", "wb+") as file:
  File "aioring/aio.pyx", line 263, in __aexit__
    await self.close()
  File "aioring/aio.pyx", line 793, in close
    await self._writer.close()
  File "aioring/aio.pyx", line 763, in close
    async with self._write_lock:
  File "aioring/aio.pyx", line 764, in aioring.aio.AsyncBufferedWriter.close
    await self.raw.close()
  File "aioring/aio.pyx", line 1130, in close
    self.__closed = True
AttributeError: 'aioring.aio.AsyncFileIO' object has no attribute '_AsyncFileIO__closed'

...

----------------------------------------------------------------------
Ran 39 tests in 0.147s

FAILED (errors=10)
```

After the changes:
```
.......................................
----------------------------------------------------------------------
Ran 39 tests in 0.158s

OK
```